### PR TITLE
feat(useRef): finish workshop 5

### DIFF
--- a/src/__tests__/05.js
+++ b/src/__tests__/05.js
@@ -1,10 +1,10 @@
 import * as React from 'react'
-import {render} from '@testing-library/react'
-import App from '../final/05'
-// import App from '../exercise/05'
+import { render } from '@testing-library/react'
+// import App from '../final/05'
+import App from '../exercise/05'
 
 test('calls VanillaTilt.init with the root node', () => {
-  const {container, unmount} = render(<App />)
+  const { container, unmount } = render(<App />)
   const tiltRoot = container.querySelector('.tilt-root')
   expect(tiltRoot).toHaveProperty('vanillaTilt')
 

--- a/src/exercise/05-hooks.js
+++ b/src/exercise/05-hooks.js
@@ -1,0 +1,40 @@
+// useRef and useEffect: DOM interaction
+// 💯 (alternate) migrate from classes
+// http://localhost:3000/isolated/exercise/05-classes.js
+
+import * as React from 'react'
+import VanillaTilt from 'vanilla-tilt'
+
+// If you'd rather practice refactoring a class component to a function
+// component with hooks, then go ahead and do this exercise.
+function Tilt(props) {
+  const tiltRef = React.useRef()
+
+  React.useEffect(() => {
+    const tiltNode = tiltRef.current
+    const vanillaTiltOptions = {
+      max: 25,
+      speed: 400,
+      glare: true,
+      'max-glare': 0.5
+    }
+    VanillaTilt.init(tiltNode, vanillaTiltOptions)
+    return () => tiltNode.vanillaTilt.destroy()
+  }, [])
+
+  return (
+    <div ref={tiltRef} className="tilt-root">
+      <div className="tilt-child">{props.children}</div>
+    </div>
+  )
+}
+
+function App() {
+  return (
+    <Tilt>
+      <div className="totally-centered">vanilla-tilt.js</div>
+    </Tilt>
+  )
+}
+
+export default App

--- a/src/exercise/05.js
+++ b/src/exercise/05.js
@@ -5,9 +5,9 @@ import * as React from 'react'
 // eslint-disable-next-line no-unused-vars
 import VanillaTilt from 'vanilla-tilt'
 
-function Tilt({children}) {
+function Tilt({ children }) {
   // 🐨 create a ref here with React.useRef()
-
+  const tiltRef = React.useRef()
   // 🐨 add a `React.useEffect` callback here and use VanillaTilt to make your
   // div look fancy.
   // 💰 like this:
@@ -19,6 +19,17 @@ function Tilt({children}) {
   //   'max-glare': 0.5,
   // })
   //
+  React.useEffect(() => {
+    const tiltNode = tiltRef.current
+    VanillaTilt.init(tiltNode, {
+      max: 25,
+      speed: 400,
+      glare: true,
+      'max-glare': 0.5,
+    })
+    return () => tiltNode.vanillaTilt.destroy()
+  }, [])
+
   // 💰 Don't forget to return a cleanup function. VanillaTilt.init will add an
   // object to your DOM node to cleanup:
   // `return () => tiltNode.vanillaTilt.destroy()`
@@ -29,7 +40,7 @@ function Tilt({children}) {
 
   // 🐨 add the `ref` prop to the `tilt-root` div here:
   return (
-    <div className="tilt-root">
+    <div className="tilt-root" ref={tiltRef}>
       <div className="tilt-child">{children}</div>
     </div>
   )


### PR DESCRIPTION
https://reactjs.org/docs/hooks-reference.html#useref

In this example, we append ref to a react node. Remember, every DOM node appears on page is when React calls `React.render` function. To access DOM, we should pass a reference to a react node, and do its side effect in `useEffect` hook.